### PR TITLE
use existing libxml2 easyblock, use %(pyver)s

### DIFF
--- a/easybuild/easyconfigs/l/libxml2/libxml2-2.9.3-foss-2016a-Python-2.7.11.eb
+++ b/easybuild/easyconfigs/l/libxml2/libxml2-2.9.3-foss-2016a-Python-2.7.11.eb
@@ -1,7 +1,6 @@
-easyblock = 'ConfigureMake'
-
 name = 'libxml2'
 version = '2.9.3'
+versionsuffix = '-Python-%(pyver)s'
 
 homepage = 'http://xmlsoft.org/'
 description = """Libxml2 is the XML C parser and toolchain developed for the Gnome project (but usable
@@ -18,13 +17,9 @@ sources = [SOURCELOWER_TAR_GZ]
 
 configopts = 'CC="$CC" CXX="$CXX" --with-pic --with-zlib=$EBROOTZLIB'
 
-pythonver = '2.7.11'
-pythonshortver = '.'.join(pythonver.split('.')[:2])
-versionsuffix = '-%s-%s' % ('Python', pythonver)
-
 dependencies = [
     ('zlib', '1.2.8'),
-    ('Python', pythonver),
+    ('Python', '2.7.11'),
 ]
 
 moduleclass = 'lib'


### PR DESCRIPTION
style fixes for https://github.com/hpcugent/easybuild-easyconfigs/pull/2786

@SimonPinches if you merge this, your PR will be updated

The `%(pyver)s` template is new, the idea is to gradually switch to using this in all easyconfigs, and certainly to use it consistently in new easyconfigs.

For libxml2, there is a custom easyblock available for that builds libxml2 wit Python bindings, so it's better to use that.
